### PR TITLE
login_presenter.dart:Provide argument of String type instead of Error…

### DIFF
--- a/lib/pages/login/login_presenter.dart
+++ b/lib/pages/login/login_presenter.dart
@@ -15,6 +15,6 @@ class LoginPagePresenter {
     api
         .login(username, password)
         .then((user) => _view.onLoginSuccess(user))
-        .catchError((onError) => _view.onLoginError(onError));
+        .catchError((onError) => _view.onLoginError(onError.toString()));
   }
 }


### PR DESCRIPTION
… type

* onLoginError accepts String type argument but onError return Error type